### PR TITLE
Fix vulnerable dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Styleguide
+Styleguide [![Known Vulnerabilities](https://snyk.io/test/github/devbridge/Styleguide/badge.svg)](https://snyk.io/test/github/devbridge/Styleguide)
 ===
 Living Styleguide Made Easy
 

--- a/package.json
+++ b/package.json
@@ -38,17 +38,21 @@
   },
   "dependencies": {
     "async": "1.2.1",
-    "body-parser": "1.12.0",
+    "body-parser": "1.12.4",
     "commander": "2.8.1",
-    "express": "4.12.2",
+    "express": "4.12.4",
     "format-json": "1.0.3",
     "jsonfile": "2.0.0",
     "lodash": "4.0.0",
     "mkdirp": "0.5.1",
     "q": "1.4.1",
-    "request": "2.55.0"
+    "request": "2.68.0"
   },
   "devDependencies": {
+    "snyk": "^1.14.1",
     "morgan": "1.5.1"
+  },
+  "scripts": {
+    "test": "snyk test"
   }
 }


### PR DESCRIPTION
Styleguide currently has 7 vulnerable dependencies, introducing 3 different types of known vulnerabilities. You can see details here (note this points to the latest commit hash at the time of this PR): https://snyk.io/test/github/devbridge/Styleguide/1bcc677fac6a9d244d918fbd25d65b138789c361

This PR upgrades the vulnerable dependencies to the minimal version that isn't vulnerable. Neither is a major upgrade, so should have no disruption.

I also created a new `npm test` script and added snyk test to it (I didn't see any other automated tests in there). Once you add CI tests, this test will help the project stay vulnerability free (will fail the test if new vulns are introduced). I recommend you also monitor the project by running `snyk wizard` in it - will alert you (via email) when a new vulnerability that affects your dependencies is disclosed.

Lastly, to show the world you're doing a good job on security (and that they should care), I took the liberty of adding a badge stating you're free of known vulnerabilities. If you're gonna be awesome, no reason to hide it!
Note that the badge works off the latest master branch, so it'll show red until you actually merge this in.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)
