### PR TITLE
Add default JS resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ You can add project name, project logo or change settings modifying `config.txt`
   "projectName": "", //Project name
   "projectUrl": "",  //Domain name of your project
   "projectLogo": "", //path to your project logo
+  "defaultJsResources": [], //Javascript resources that will load for all snippets automatically
   "jsResources": [], //Javascript resources that's going to be included into the snippets
   "viewportWidths": [ //Predefinded viewport breakpoints
     480,

--- a/bin/styleguide
+++ b/bin/styleguide
@@ -21,6 +21,7 @@ var getMainConfig = function(folder) {
     projectUrl: '',
     projectLogo: '',
 
+    defaultJsResources: [],
     jsResources: [],
     viewportWidths: [320, 480, 768, 1024, 1200],
 

--- a/templates/js/iframes.js
+++ b/templates/js/iframes.js
@@ -64,6 +64,16 @@ var iframesService = (function ($, snippetService) {
         });
     };
 
+    module.getDefaultJavaScripts = function (callback) {
+        getConfig(function (config) {
+            if (config.defaultJsResources) {
+                callback(config.defaultJsResources);
+            } else {
+                console.log('No default JavaScript files are defined in configuration to load into iframe.');
+            }
+        });
+    };
+
     module.getJavaScripts = function (callback) {
         getConfig(function (config) {
             if (config.jsResources) {

--- a/templates/js/snippetActions.js
+++ b/templates/js/snippetActions.js
@@ -91,6 +91,14 @@ var snippetActions = (function ($, snippetService, iframesService, editorService
             .find('script')
             .remove();
 
+        iframesService.getDefaultJavaScripts(function (defaultJsResources) {
+            length = defaultJsResources.length;
+
+            for (index = 0; index < length; index++) {
+                injectJavaScript(document.getElementById(frameId.attr('id')), defaultJsResources[index]);
+            }
+        });
+
         if (includeJs === true || includeJs === "true") {
             rawJsFrame = document.getElementById(frameId.attr('id'));
 


### PR DESCRIPTION
Loads default scripts for all snippets. One use case is needing to
load fonts through a service like Typekit where JS loading is the only
option. Needed for loading font in general section (under font and typography).
Note: quick and dirty solution. Could use refactoring.
