### PR TITLE
Fix wrong quotes for json

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Scraping scss files you can automatically generate color palette or create a lis
 
 * Next, declare scss file path references in styleguide config file:
 
-    `"sassVariables": ['/path/to/your/project/scss/file.scss']`
+    `"sassVariables": ["/path/to/your/project/scss/file.scss"]`
 
 * Lastly, open styleguide web page and select from the menu 'Scrape Variables'. Note, make sure you have styleguide server running.
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -494,7 +494,7 @@
             <span class="sg-missing-list-child">
                 <code class="sg-sample-code">
                     <span>{</span><br />
-                    <span>&nbsp;&nbsp;sassVariables: [&#39;/scss/_variables.scss&#39;],</span><br />
+                    <span>&nbsp;&nbsp;sassVariables: [&#34;/scss/_variables.scss&#34;],</span><br />
                     <span>&nbsp;&nbsp;maxSassIterations: 2000</span><br />
                     <span>}</span>
                 </code>


### PR DESCRIPTION
If you use the single quote like suggested you get an Unexpected token error. So maybe we should make a double quote out of this
