### PR TITLE
cssVariables not sassVariables

### DIFF
--- a/_demo/styleguide/config.txt
+++ b/_demo/styleguide/config.txt
@@ -12,7 +12,7 @@
   ],
   "serverPort": 8889,
   "snippetTemplate": "styleguide\\template.html",
-  "sassVariables": ["styles.scss"],
+  "cssVariables": ["styles.scss"],
   "maxSassIterations": 2000,
   "database": "styleguide\\db",
   "categories": "styleguide\\db\\categories.txt",


### PR DESCRIPTION
Was trying the demo and the scrape variables feature didn't work. I found out the `sassVariables` in the `config.txt` is suppose to be `cssVariables`
